### PR TITLE
fix ast: 给Literal加上类型

### DIFF
--- a/src/main/java/ASTParser.java
+++ b/src/main/java/ASTParser.java
@@ -1,6 +1,7 @@
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import symboltable.Scope;
+import symboltable.SimpleType;
 import symboltable.Symbol;
 import symboltable.Type;
 
@@ -411,12 +412,9 @@ class Literal extends ScopePointer implements ExpressionNode {
 
   public String raw;
 
-  Literal() {
-
-  }
-
-  Literal(CLParserParser.IntegerLiteralContext ctx) {
-    raw = ctx.getText();
+  Literal(String raw, Type type) {
+    this.raw = raw;
+    evalType = type;
   }
 
   @Override
@@ -464,14 +462,17 @@ public class ASTParser extends CLParserBaseVisitor<Node> {
 
   @Override
   public Node visitIntegerLiteral(CLParserParser.IntegerLiteralContext ctx) {
-    return new Literal(ctx);
+    return new Literal(ctx.getText(), new SimpleType("Number"));
+  }
+
+  @Override
+  public Node visitFloatLiteral(CLParserParser.FloatLiteralContext ctx) {
+    return new Literal(ctx.getText(), new SimpleType("Number"));
   }
 
   @Override
   public Node visitString(CLParserParser.StringContext ctx) {
-    Literal l = new Literal();
-    l.raw = ctx.getText();
-    return l;
+    return new Literal(ctx.getText(), new SimpleType("String"));
   }
 
   @Override


### PR DESCRIPTION
1. 给Literal加上类型（ScopePointer父类的evalType）
2. 补上遗忘的visitFloat

虽说后面ScopePointer可能要大改，但我觉得即使那时给Literal加类型也是要有的