### PR TITLE
feat(chore): 给TypeCheck、SymbolCheck加上debug选项

### DIFF
--- a/src/main/java/check/SymbolCheck.java
+++ b/src/main/java/check/SymbolCheck.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import static util.Error.die;
 import static util.Type.getType;
+import static util.Error.debugSymbolCheck;
 
 public class SymbolCheck extends ASTBaseListener {
 
@@ -26,25 +27,23 @@ public class SymbolCheck extends ASTBaseListener {
         currentScope = currentScope.getEnclosingScope();
     }
 
-//    @Override
-//    public void exitLiteral(AST.Literal node) {
-//        System.out.println("exit " + node.evalType + " literal");
-//        System.out.println(node.raw);
-//    }
-
     @Override
     public void enterProgram(Program ctx) {
         globals = new GlobalScope(new PredefinedScope(null));
         currentScope = globals;
-        System.out.println(">>>>> enter program");
-        System.out.println("stdlib: " + currentScope.getEnclosingScope());
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter program");
+            System.out.println("stdlib: " + currentScope.getEnclosingScope());
+        }
         ctx.scope = globals;
     }
 
     @Override
     public void exitProgram(Program ctx) {
-        System.out.println("<<<<< exit program:");
-        System.out.println(globals);
+        if (debugSymbolCheck) {
+            System.out.println("<<<<< exit program:");
+            System.out.println(globals);
+        }
     }
 
     @Override
@@ -53,7 +52,9 @@ public class SymbolCheck extends ASTBaseListener {
         String typeType = ctx.returnType;
         Type type = getType(typeType);
 
-        System.out.println(">>>>> enter procedure " + name);
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter procedure " + name);
+        }
 
         ProcedureSymbol procedureSymbol = new ProcedureSymbol(name, type, currentScope);
         currentScope.define(procedureSymbol);
@@ -75,7 +76,10 @@ public class SymbolCheck extends ASTBaseListener {
         String name = "^\\" + UUID.randomUUID().toString().replace("-", "");
         Type type = getType(retType);
 
-        System.out.println(">>>>> enter lambda " + name);
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter lambda " + name);
+
+        }
 
         ProcedureSymbol procedureSymbol = new ProcedureSymbol(name, type, currentScope);
         currentScope.define(procedureSymbol);
@@ -102,7 +106,9 @@ public class SymbolCheck extends ASTBaseListener {
     // 好日子来临力！现在for、if、else也改回来啦！
     @Override
     public void enterBlock(Block ctx) {
-        System.out.println(">>>>> enter block(prog/lamb/proc/for/while/if-else):");
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter block(prog/lamb/proc/for/while/if-else):");
+        }
         LocalScope localScope = new LocalScope(currentScope);
         pushScope(ctx, localScope);
 
@@ -120,14 +126,18 @@ public class SymbolCheck extends ASTBaseListener {
     }
 
     private void exitBlockKai(String exitMessage) {
-        System.out.println(exitMessage);
-        System.out.println(currentScope);
+        if (debugSymbolCheck) {
+            System.out.println(exitMessage);
+            System.out.println(currentScope);
+        }
         popScope();
     }
 
     @Override
     public void enterForBlock(ForBlock ctx) {
-        System.out.println(">>>>> enter for:");
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter for:");
+        }
         if (null != ctx.iter_type) {
             enterBlockKai(ctx);
             // 创建新变量
@@ -146,21 +156,27 @@ public class SymbolCheck extends ASTBaseListener {
             // 创建了新变量就要弹出作用域
             exitBlockKai("<<<<< exit for:");
         } else {
-            System.out.println("<<<<< exit for:");
+            if (debugSymbolCheck) {
+                System.out.println("<<<<< exit for:");
+            }
         }
         loopWatcher.popLoop();
     }
 
     @Override
     public void enterWhileBlock(WhileBlock ctx) {
-        System.out.println(">>>>> enter while:");
+        if (debugSymbolCheck) {
+            System.out.println(">>>>> enter while:");
+        }
         enterBlockKai(ctx);
         loopWatcher.pushLoop();
     }
 
     @Override
     public void exitWhileBlock(WhileBlock ctx) {
-        exitBlockKai("<<<<< exit while:");
+        if (debugSymbolCheck) {
+            exitBlockKai("<<<<< exit while:");
+        }
         loopWatcher.popLoop();
     }
 

--- a/src/main/java/check/TypeCheck.java
+++ b/src/main/java/check/TypeCheck.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static util.Error.debugTypeCheck;
 import static util.Error.die;
 import static util.Type.*;
 
@@ -45,7 +46,9 @@ public class TypeCheck extends ASTBaseListener {
 
     @Override
     public void exitCallExpression(CallExpression ctx) {
-        System.out.println("exit call" + ctx.symbol);
+        if (debugTypeCheck) {
+            System.out.println("exit call" + ctx.symbol);
+        }
         if (null == ctx.symbol) {
             die("Type Check: CallExpression", "Procedure symbol " + ctx.callee.name + " not found!");
         }
@@ -99,14 +102,13 @@ public class TypeCheck extends ASTBaseListener {
 
     @Override
     public void exitMemberExpression(MemberExpression ctx) {
-        System.out.println("exit mem" + ctx.property.symbol + "\n\n");
+        if (debugTypeCheck) {
+            System.out.println("exit mem" + ctx.property.symbol + "\n\n");
+        }
         // 原来 MemberExpression 竟然是包括方法调用……
         ExpressionNode callee = ctx.property;
         assert callee.symbol instanceof ProcedureSymbol;
         ProcedureSymbol procedure = (ProcedureSymbol) callee.symbol;
-        if (procedure.name.equals("toString")) {
-            System.out.println("ssss");
-        }
         if (procedure.isMethod()) {
             List<Type> signature = procedure.signature;
             Type selfType = signature.get(0);
@@ -143,11 +145,6 @@ public class TypeCheck extends ASTBaseListener {
         }
         ctx.evalType = ctx.symbol.type;
     }
-
-//    @Override
-//    public void exitLiteral(Literal ctx) {
-//        // 是放在这里好还是建立AST时？
-//    }
 
     @Override
     public void exitArithmeticExpression(ArithmeticExpression ctx) {

--- a/src/main/java/util/Error.java
+++ b/src/main/java/util/Error.java
@@ -5,4 +5,7 @@ public class Error {
         System.err.println(errType + "\n\t" + errMsg);
         System.exit(0);
     }
+
+    final public static boolean debugSymbolCheck = false;
+    final public static boolean debugTypeCheck = false;
 }

--- a/src/main/java/util/Type.java
+++ b/src/main/java/util/Type.java
@@ -4,6 +4,8 @@ import symboltable.CompositeType;
 import symboltable.GenericType;
 import symboltable.SimpleType;
 
+import static util.Error.debugTypeCheck;
+
 public class Type {
     public static symboltable.Type getType(String string) {
         // 可以维护一个“类型池”，不知道有没有必要
@@ -17,8 +19,10 @@ public class Type {
     }
 
     public static boolean sameParameterType(symboltable.Type argType, symboltable.Type parType) {
-        System.out.println("argType " + argType);
-        System.out.println("parType " + parType);
+        if (debugTypeCheck) {
+            System.out.println("argType " + argType);
+            System.out.println("parType " + parType);
+        }
         String parString = parType.toString();
         String argString = argType.toString();
 


### PR DESCRIPTION
觉得给每个输出都加if (debug) 判断做太多无用功了，后来发现[如果debug是常量，if语句达不到的分支在编译期间就会被略去](https://stackoverflow.com/a/1813871)，所以在util.Error里设置了常量的debug选项。

不过这样还是丑，太多debug专用的if和正常if混在一起了。