### PR TITLE
fix(ast, typecheck, symtab): 把调用方法变为CallExpression，支持函数重载

### DIFF
--- a/examples/decimal.cl
+++ b/examples/decimal.cl
@@ -21,4 +21,4 @@ Number x7 = 0x5_2            // OK (hexadecimal literal)
 Number x9 = 0_52             // OK (octal literal)
 Number x10 = 05_2            // OK (octal literal)
 
-print((pi+x2+x10).toString())
+print(pi+x2+x10)

--- a/examples/nim.cl
+++ b/examples/nim.cl
@@ -15,5 +15,5 @@ while true {
             counter = counter + 1
         }
     }
-    print(counter.toString)
+    print(counter.toString())
 }

--- a/examples/nim.cl
+++ b/examples/nim.cl
@@ -15,5 +15,5 @@ while true {
             counter = counter + 1
         }
     }
-    print(counter.toString())
+    print(counter)
 }

--- a/examples/proc.cl
+++ b/examples/proc.cl
@@ -2,4 +2,4 @@ proc add1(Number x) -> Number {
     x + 1
 }
 
-print(add1(123).toString())
+print(add1(123))

--- a/examples/samename.cl
+++ b/examples/samename.cl
@@ -5,6 +5,6 @@ proc add1(Number x) -> Number {
 Number x = 1
 for x in [1..2] {
     for Number x in [3..4] {
-        print(add1(x).toString())
+        print(add1(x))
     }
 }

--- a/src/main/java/ast/ASTParser.java
+++ b/src/main/java/ast/ASTParser.java
@@ -179,16 +179,26 @@ public class ASTParser extends CLParserBaseVisitor<Node> {
 
   @Override
   public Node visitMember(CLParserParser.MemberContext ctx) {
-    MemberExpression me = new MemberExpression();
-    me.object = (ExpressionNode) visit(ctx.expression());
     if (ctx.IDENTIFIER() != null) {
       // member is AST.Identifier
+      MemberExpression me = new MemberExpression();
+      me.object = (ExpressionNode) visit(ctx.expression());
       me.property = new Identifier(ctx.IDENTIFIER().getText());
+      return me;
     } else {
       // member is Cal
-      me.property = (ExpressionNode) visit(ctx.procedureCall());
+      CLParserParser.ProcedureCallContext pctx = ctx.procedureCall();
+      CallExpression ce = new CallExpression();
+      ce.isMethodCall = true;
+      ce.callee = new FunctionIdentifier(pctx.IDENTIFIER().getText());
+      ce.arguments = new ArrayList<ExpressionNode>() {{
+        add((ExpressionNode) visit(ctx.expression()));
+      }};
+      if (null != pctx.expressionList()) {
+        pctx.expressionList().expression().stream().map(e -> (ExpressionNode) visit(e)).forEachOrdered(ce.arguments::add);
+      }
+      return ce;
     }
-    return me;
   }
 
 

--- a/src/main/java/ast/CallExpression.java
+++ b/src/main/java/ast/CallExpression.java
@@ -10,6 +10,7 @@ public class CallExpression extends ExpressionNode {
   // identifier or AST.MemberExpression
   public FunctionIdentifier callee;
   public List<ExpressionNode> arguments;
+  public boolean isMethodCall = false;
 
 
   @Override

--- a/src/main/java/ast/Identifier.java
+++ b/src/main/java/ast/Identifier.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public class Identifier extends ExpressionNode {
   public String name;
+  public boolean isProc = false;
 
   Identifier(CLParserParser.IdContext ctx) {
     name = ctx.getText();

--- a/src/main/java/symboltable/PredefinedScope.java
+++ b/src/main/java/symboltable/PredefinedScope.java
@@ -11,13 +11,13 @@ public class PredefinedScope extends BaseScope {
         define(mkproc(this, "split", "List<String>", mkprmtr("String", "self")));
         define(mkproc(this, "print", "String", mkprmtr("String"))); //todo 返回什么？
 
-        define(mkproc(this, "toString", "String", mkprmtr("Number", "self")));
+        define(mkproc(this, "toString", "String", mkprmtr("TypeA", "self")));
         define(mkproc(this, "toNumber", "Number", mkprmtr("String", "self")));
 
         //todo
         define(mkproc(this, "filter", "List<TypeA>", mkprmtr("List<TypeA>", "self"), mkprmtr("Proc")));
         define(mkproc(this, "map", "List<TypeA>", mkprmtr("List<TypeA>", "self"), mkprmtr("Proc")));
-        define(mkproc(this, "forEach", "List<TypeB>", mkprmtr("List<TypeA>", "self"), mkprmtr("Proc")));
+        define(mkproc(this, "forEach", "?", mkprmtr("List<TypeA>", "self"), mkprmtr("Proc")));
         define(mkproc(this, "reduce", "Number", mkprmtr("Proc"), mkprmtr("List<TypeA>"), mkprmtr("TypeA")));
     }
 

--- a/src/main/java/symboltable/PredefinedScope.java
+++ b/src/main/java/symboltable/PredefinedScope.java
@@ -9,7 +9,8 @@ public class PredefinedScope extends BaseScope {
 
         define(mkproc(this, "input", "String"));
         define(mkproc(this, "split", "List<String>", mkprmtr("String", "self")));
-        define(mkproc(this, "print", "String", mkprmtr("String"))); //todo 返回什么？
+        define(mkproc(this, "print", "String", mkprmtr("String")));
+        define(mkproc(this, "print", "String", mkprmtr("Number")));
 
         define(mkproc(this, "toString", "String", mkprmtr("TypeA", "self")));
         define(mkproc(this, "toNumber", "Number", mkprmtr("String", "self")));

--- a/src/main/java/symboltable/ProcedureSymbol.java
+++ b/src/main/java/symboltable/ProcedureSymbol.java
@@ -1,13 +1,10 @@
 package symboltable;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
 public class ProcedureSymbol extends Symbol implements Scope {
     LinkedHashMap<String, Symbol> parameters = new LinkedHashMap<>();
     Scope enclosingScope;
-//    public ProcedureSymbol next = null;
     public List<Type> signature = new ArrayList<>();
 
     public ProcedureSymbol(String name, Type retType, Scope enclosingScope) {
@@ -30,7 +27,7 @@ public class ProcedureSymbol extends Symbol implements Scope {
     public void define(Symbol sym) {
         parameters.put(sym.name, sym);
         sym.scope = this;
-        signature.add(signature.size()-1, sym.type);
+        signature.add(signature.size() - 1, sym.type);
     }
 
     @Override
@@ -50,6 +47,16 @@ public class ProcedureSymbol extends Symbol implements Scope {
         return parameters.get(name);
     }
 
+    @Override
+    public boolean hasProcedure(String name) {
+        return enclosingScope.hasProcedure(name);
+    }
+
+    @Override
+    public LinkedList<ProcedureSymbol> resolveProcedures(String name) {
+        return enclosingScope.resolveProcedures(name);
+    }
+
     public boolean isMethod() {
         return null != parameters.get("self"); // todo 检查是不是只有第一个参数叫self
     }
@@ -57,5 +64,18 @@ public class ProcedureSymbol extends Symbol implements Scope {
     public String toString() {
         String[] temp = super.toString().split(":");
         return "proc " + temp[0] + " " + parameters.values() + ":" + temp[1];
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProcedureSymbol that = (ProcedureSymbol) o;
+        return signature.equals(that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/symboltable/Scope.java
+++ b/src/main/java/symboltable/Scope.java
@@ -1,5 +1,7 @@
 package symboltable;
 
+import java.util.LinkedList;
+
 public interface Scope {
     String getScopeName();
 
@@ -22,4 +24,14 @@ public interface Scope {
      * 只看当前scope有没有（用于检查重定义）
      */
     Symbol resolveWithin(String name);
+
+    /**
+     * 确定有没有某个函数
+     */
+    boolean hasProcedure(String name);
+
+    /**
+     * 返回所有同名函数
+     */
+    LinkedList<ProcedureSymbol> resolveProcedures(String name);
 }

--- a/src/test/java/ASTOlderTester.java
+++ b/src/test/java/ASTOlderTester.java
@@ -31,6 +31,11 @@ public class ASTOlderTester {
         @Override
         public void exitCallExpression(CallExpression ctx) {
             System.out.println("exit call" + ctx.symbol);
+            for (ExpressionNode expr :
+                    ctx.arguments) {
+                System.out.println(expr.toString());
+            }
+            System.out.println("\n\n");
         }
 
         @Override


### PR DESCRIPTION
之前说的，把调用方法变为CallExpression。
我没发现有哪里破坏IR了，但不确定，所以请您检查一下。

另外修复了一个例子，还有forEach的类型，这样merge到develop就能过测试了。